### PR TITLE
Using version-less API endpoint

### DIFF
--- a/plugins/webservices_list.php
+++ b/plugins/webservices_list.php
@@ -3,7 +3,7 @@
 require_once APP_PATH_DOCROOT . 'ControlCenter/header.php';
 
 $settings = $module->getFormattedSettings();
-$base_url = $module->getUrl('plugins/endpoint.php', true);
+$base_url = $module->getUrl('plugins/endpoint.php', true, true);
 
 $rows = array();
 foreach ($settings['queries'] as $query_info) {


### PR DESCRIPTION
Fixes #8.

Review steps:
- [x] Make sure you have at least one configured web service
- [ ] Go to Control Center > REDCap Web Services page and make sure the URLs listed do not include your REDCap version