### PR TITLE
Update config.js to avoid clash with other modules overloading resetConfigInstances

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -1,41 +1,48 @@
 $(document).ready(function() {
     var $modal = $('#external-modules-configure-modal');
 
-    ExternalModules.Settings.prototype.resetConfigInstancesOld = ExternalModules.Settings.prototype.resetConfigInstances;
-    ExternalModules.Settings.prototype.resetConfigInstances = function() {
-        ExternalModules.Settings.prototype.resetConfigInstancesOld();
+    // check if other modules have set this to avoid infinite redefinition loop
+    if (typeof ExternalModules.Settings.prototype.resetConfigInstancesOld === 'undefined') {
+        ExternalModules.Settings.prototype.resetConfigInstancesOld = ExternalModules.Settings.prototype.resetConfigInstances;
+    }
 
-        // Making sure we are overriding this modules's modal only.
-        if ($modal.data('module') !== REDCapWebServices.modulePrefix) {
-            return;
-        }
+    // fire on clicking "configure" for any module
+    $modal.on('show.bs.modal', function() {
+        ExternalModules.Settings.prototype.resetConfigInstances = function() {
+            ExternalModules.Settings.prototype.resetConfigInstancesOld();
 
-        // Adding "SELECT" prefix to SQL query field.
-        $('[field="query_sql"]').each(function() {
-            if ($(this).hasClass('select-prefix-set')) {
+            // Making sure we are overriding this modules's modal only.
+            if ($modal.data('module') !== REDCapWebServices.modulePrefix) {
                 return;
             }
 
-            $(this).children('.external-modules-input-td').prepend('<span>SELECT</span>');
-            $(this).addClass('select-prefix-set');
-        });
+            // Adding "SELECT" prefix to SQL query field.
+            $('[field="query_sql"]').each(function() {
+                if ($(this).hasClass('select-prefix-set')) {
+                    return;
+                }
 
-        // Adjusting columns widths to make room for the SQL query field.
-        $modal.find('tr').each(function() {
-            $(this).find('td').first().css('width', '50%');
-        });
+                $(this).children('.external-modules-input-td').prepend('<span>SELECT</span>');
+                $(this).addClass('select-prefix-set');
+            });
 
-        ExternalModules.configsByPrefix[REDCapWebServices.modulePrefix]['system-settings'].forEach(function(setting) {
-            if (setting.type === 'sub_settings') {
-                setting.sub_settings.forEach(function(subSetting) {
-                    setHelper(subSetting);
-                });
-            }
-            else {
-                setHelper(setting);
-            }
-        });
-    }
+            // Adjusting columns widths to make room for the SQL query field.
+            $modal.find('tr').each(function() {
+                $(this).find('td').first().css('width', '50%');
+            });
+
+            ExternalModules.configsByPrefix[REDCapWebServices.modulePrefix]['system-settings'].forEach(function(setting) {
+                if (setting.type === 'sub_settings') {
+                    setting.sub_settings.forEach(function(subSetting) {
+                        setHelper(subSetting);
+                    });
+                }
+                else {
+                    setHelper(setting);
+                }
+            });
+        }
+    });
 
     function setHelper(setting) {
         if (Array.isArray(setting)) {


### PR DESCRIPTION
Addresses a bug that occurs if any other module is defining `ExternalModules.Settings.prototype.resetConfigInstancesOld` without checking if it was already defined with`typeof ExternalModules.Settings.prototype.resetConfigInstancesOld === 'undefined'`. This prevents an infinite loop from occurring.

Additionally prevents a much less important bug wherein launching this module's config, then a different module's config (which is safely overriding resetConfigInstances), the "SELECT" is no longer prepended to the free text area for SQL.

## Testing
1. Enable this module and Data Driven Project Banner (DDPB)
1. Navigate to the system level config menu and open your browser console
1. Open the module configuration for either this module or DDPB